### PR TITLE
chore: bump golang version to 1.22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,9 +21,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Cache Go modules
         uses: actions/cache@v3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,9 +8,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/castai/spot-handler
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
Should fix `CVE-2024-24790`